### PR TITLE
Fix numexpr version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ pandas==0.24.2; python_version <= '2.7'
 pandas>=1.1.0; python_version > '3.3'
 numpy==1.16.6; python_version <= '2.7'
 numpy>=1.19.1; python_version > '3.3'
-numexpr==2.7.1; python_version <= '2.7'
-numexpr>=2.7.1; python_version > '3.3'
+numexpr
 pytest

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 # Check this Python version is supported
 if any([v < (2, 6), (3,) < v < (3, 5)]):
-    raise Exception("Unsupported Python version %d.%d. Requires Python >= 2.7 "
+    raise Exception("Unsupported Python version %d.%d. Requires Python == 2.7 "
                     "or >= 3.5." % v[:2])
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -41,15 +41,15 @@ def get_version():
 # Sources & libraries
 sources = []
 optional_libs = []
-install_requires = []
-setup_requires = []
+install_requires = ['numexpr']
+setup_requires = ['numexpr']
 tests_requires = ['pytest']
 if v < (3,):
-    install_requires.extend(['pyarrow==0.16.0', 'pandas==0.24.2', 'numpy==1.16.6', 'numexpr==2.7.1'])
-    setup_requires.extend(['pyarrow==0.16.0', 'pandas==0.24.2', 'numpy==1.16.6', 'numexpr==2.7.1'])
+    install_requires.extend(['pyarrow<0.17', 'pandas<0.25', 'numpy<1.17'])
+    setup_requires.extend(['pyarrow<0.17', 'pandas<0.25', 'numpy<1.17'])
 else:
-    install_requires.extend(['pyarrow>=1.0.0', 'pandas>=1.1.0', 'numpy>=1.19.1', 'numexpr>=2.7.1'])
-    setup_requires.extend(['pyarrow>=1.0.0', 'pandas>=1.1.0', 'numpy>=1.19.1', 'numexpr>=2.7.1'])
+    install_requires.extend(['pyarrow>=1', 'pandas>=1.1', 'numpy>=1.19.1'])
+    setup_requires.extend(['pyarrow>=1', 'pandas>=1.1', 'numpy>=1.19.1'])
 
 extras_requires = []
 


### PR DESCRIPTION
This new release breaks backend build as follows. This PR fixes requirements specification for `numexpr` and relaxes others to minimize such behavior.

```
Collecting parquery>=0.1.15
ERROR: Some build dependencies for parquery>=0.1.15 from https://files.pythonhosted.org/packages/16/32/a5c7f707b61317f8f3d7a25f330a1fd0353ca9676d32412c93dc6afe3cc8/parquery-0.2.0.tar.gz#sha256=d0e69e6b204f4114c66f3986de333d2dd46aab61ffe8a8869eac0e810d524ace
 (from parqueryd==0.1.33-&gt;metadata==1.0.0) conflict with the backend 
dependencies: numexpr==2.7.3 is incompatible with numexpr==2.7.1.
```