### PR TITLE
feat: add configurable DuckDB memory limit via DUCKDB_MEMORY_LIMIT env var

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes for ParQuery
 
+## Release 2.0.7
+- Add configurable DuckDB memory limit via `DUCKDB_MEMORY_LIMIT` environment variable
+- Prevents DuckDB OOM on containers with limited memory (e.g. ECS tasks with multiple Gunicorn workers)
+- When set (e.g. `DUCKDB_MEMORY_LIMIT=2GB`), DuckDB spills to temp storage instead of allocating unbounded memory
+- No performance penalty — benchmark shows equal or faster execution with bounded memory
+
 ## Release 2.0.6
 - Add specific functions to public api for imports
 

--- a/parquery/__init__.py
+++ b/parquery/__init__.py
@@ -27,7 +27,7 @@ from parquery.transport import (
 from parquery.write import df_to_parquet
 
 pre_release_version = os.getenv("PRE_RELEASE_VERSION", "")
-__version__: str = pre_release_version if pre_release_version else "2.0.6"
+__version__: str = pre_release_version if pre_release_version else "2.0.7"
 
 __all__ = [
     "aggregate_pq",

--- a/parquery/aggregate_duckdb.py
+++ b/parquery/aggregate_duckdb.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import gc
 import logging
+import os
 from typing import Any
 
 try:
@@ -16,6 +17,10 @@ import pyarrow as pa
 from parquery.tool import DataFilter
 
 logger = logging.getLogger(__name__)
+
+# DuckDB memory limit per connection. Set via DUCKDB_MEMORY_LIMIT env var.
+# Examples: "4GB", "2GB", "512MB". Default: no limit (DuckDB manages automatically).
+DUCKDB_MEMORY_LIMIT: str | None = os.environ.get("DUCKDB_MEMORY_LIMIT")
 
 
 def aggregate_pq_duckdb(
@@ -134,8 +139,12 @@ def call_duckdb(sql) -> Any:
         - Uses in-memory database (:memory:) for temporary processing.
         - Connection is automatically closed after query execution.
         - Results are streamed via RecordBatchReader and converted to Table.
+        - Set DUCKDB_MEMORY_LIMIT env var (e.g. "4GB") to cap memory per query.
     """
-    conn = duckdb.connect(":memory:")
+    config = {}
+    if DUCKDB_MEMORY_LIMIT:
+        config["memory_limit"] = DUCKDB_MEMORY_LIMIT
+    conn = duckdb.connect(":memory:", config=config)
     # arrow() returns a RecordBatchReader, convert to Table
     reader = conn.execute(sql).arrow()
     result_arrow = reader.read_all()


### PR DESCRIPTION
## Summary
- Add `DUCKDB_MEMORY_LIMIT` environment variable support to cap DuckDB memory per query connection
- When set (e.g. `DUCKDB_MEMORY_LIMIT=2GB`), DuckDB spills to temp storage instead of allocating unbounded memory
- Prevents OOM on containers with limited memory (e.g. ECS tasks running multiple Gunicorn workers)

## Context
DQE reader runs 3 Gunicorn workers in a 7.5GB ECS container. DuckDB's default behavior allocates memory without bounds, causing OOM on large shard aggregations. With `DUCKDB_MEMORY_LIMIT=2GB`, each worker caps at 2GB (3×2GB=6GB), leaving headroom for Python/OS.

## Benchmark (345M-row KCI shard, high-cardinality query)

| Limit | Time | RSS delta | Result |
|---|---|---|---|
| None (default) | 7.93s | +2,713 MB | 256K rows |
| **2GB** | **6.71s** | **+540 MB** | 256K rows |
| 512MB | 3.17s | OOM | Failed |

No performance penalty — bounded memory is actually faster due to less GC pressure.

## Changes
- `parquery/aggregate_duckdb.py`: Read `DUCKDB_MEMORY_LIMIT` env var, pass as `config` to `duckdb.connect()`
- `parquery/__init__.py`: Version bump to 2.0.7
- `RELEASE_NOTES.md`: Added 2.0.7 entry

## Test plan
- [x] All 76 existing tests pass
- [x] Verified with real 345M-row parquet file at various limits
- [ ] Deploy to DQE reader with `DUCKDB_MEMORY_LIMIT=2GB` env var