### PR TITLE
DFM-4530: per-MINOR-line hotfix CI (release-vN.M) + publish approval gate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,14 +114,35 @@ workflows:
           context: [sdlc, codeartifact-dev]
       - test-arm64:
           context: [sdlc, codeartifact-dev]
+
+      # Test runs on main + release-vN.M hotfix branches. release-v<MAJOR>.<MINOR>
+      # branches publish MAJOR.MINOR.TIMESTAMP from their own pyproject.toml. See
+      # docs/sdlc/sdlc-cicd-guide-backend.md §4b "CI workflow filters for hotfix
+      # branches" and "Governance for hotfix publishes".
+
+      # main auto-publishes — its gate is the reviewed PR merge
       - publish-package:
           context: [sdlc, codeartifact-dev]
           requires: [test, test-arm64]
           filters:
             branches:
-              only:
-                - main
-                - /^release-v\d+$/
+              only: main
+
+      # release-vN.M publishes only after a manual approval, on top of the
+      # required PR review (branch protection on release-v*)
+      - approve-release-publish:
+          type: approval
+          requires: [test, test-arm64]
+          filters:
+            branches:
+              only: /^release-v\d+\.\d+$/
+      - publish-package:
+          name: publish-package-release
+          context: [sdlc, codeartifact-dev]
+          requires: [approve-release-publish]
+          filters:
+            branches:
+              only: /^release-v\d+\.\d+$/
 
   # Feature branches: opt-in dev publish
   publish-dev:
@@ -132,7 +153,7 @@ workflows:
             branches:
               ignore:
                 - main
-                - /^release-v\d+$/
+                - /^release-v\d+\.\d+$/
       - publish-dev:
           context: [sdlc, codeartifact-dev]
           requires: [approve-publish-dev]
@@ -140,7 +161,7 @@ workflows:
             branches:
               ignore:
                 - main
-                - /^release-v\d+$/
+                - /^release-v\d+\.\d+$/
 
   create-release-branch:
     jobs:
@@ -150,7 +171,7 @@ workflows:
             branches:
               ignore:
                 - main
-                - /^release-v\d+$/
+                - /^release-v\d+\.\d+$/
       - create-release-branch:
           context: [sdlc, codeartifact-dev]
           requires: [approve-create-release-branch]
@@ -158,4 +179,4 @@ workflows:
             branches:
               ignore:
                 - main
-                - /^release-v\d+$/
+                - /^release-v\d+\.\d+$/

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes for ParQuery
 
+## Release 2.1.0
+- Open a new MINOR line so `release-v2.0` can host hotfixes against the 2.0
+  series in isolation. No runtime changes. Pairs with the per-MINOR-line
+  hotfix CI introduced in FOUN-341: `release-vN.M` branches now match the
+  package filters (`/^release-v\d+\.\d+$/`) and publishes from those branches
+  run behind the manual `approve-release-publish` gate, while `main`
+  continues to auto-publish on merge. See
+  `docs/sdlc/sdlc-cicd-guide-backend.md` §4b.
+
 ## Release 2.0.7
 - Add configurable DuckDB memory limit via `DUCKDB_MEMORY_LIMIT` environment variable
 - Prevents DuckDB OOM on containers with limited memory (e.g. ECS tasks with multiple Gunicorn workers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "parquery"
-version = "2.0.7"
+version = "2.1.0"
 description = "A query and aggregation framework for Parquet"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Change CI branch filters from `/^release-v\d+$/` to `/^release-v\d+\.\d+$/` so package hotfix branches are named per released line (`release-v2.0`) instead of per major — each branch then has one correct base and lines can be patched independently.
- Split `publish-package`: `main` auto-publishes (gate = reviewed merge), while `release-vN.M` publishes run behind a manual `approve-release-publish` job. Both paths require `test` + `test-arm64` first.
- Bump version `2.0.7` → `2.1.0` to open a new MINOR line; future `release-v2.0` hotfix versions sort below `2.1.*` on `main`.

Implements the package-hotfix flow documented in the customer repo `docs/sdlc/sdlc-cicd-guide-backend.md` §4b. Mirrors visualfabriq/metadata#1403, visualfabriq/vf_initialize_data#261, visualfabriq/forecaster-backend#70, and visualfabriq/notifications#41. Branch protection on `release-v*` is a separate repo-admin step.

## Test plan
- [ ] CircleCI config validates (`circleci config validate` / pipeline parses)
- [ ] Push to `main` still auto-publishes after `test` + `test-arm64`
- [ ] A `release-v<MAJOR>.<MINOR>` branch surfaces the `approve-release-publish` gate before publishing

---
jira: DFM-4530