### PR TITLE
DFM-4530: guard release-branch publish version line

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,10 +78,36 @@ jobs:
           tool: twine
 
   publish-package:
+    parameters:
+      assert-release-version:
+        description: >
+          On release-vN.M branches, fail if pyproject.toml's MAJOR.MINOR does not
+          match the branch line. Guards the timestamp_version invariant so a stray
+          version bump merged into a hotfix branch cannot publish out-of-line
+          artifacts (e.g. a 2.1.x build from a release-v2.0 branch).
+        type: boolean
+        default: false
     executor:
       <<: *python_executor_small
     steps:
       - checkout
+      - when:
+          condition: << parameters.assert-release-version >>
+          steps:
+            - run:
+                name: Assert pyproject.toml version matches release branch
+                command: |
+                  branch_mm="${CIRCLE_BRANCH#release-v}"
+                  pkg_ver="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")"
+                  pkg_mm="$(echo "$pkg_ver" | cut -d. -f1,2)"
+                  if [ "$pkg_mm" != "$branch_mm" ]; then
+                    echo "ERROR: pyproject.toml version $pkg_ver (MAJOR.MINOR=$pkg_mm) does not match"
+                    echo "release branch $CIRCLE_BRANCH (expected line $branch_mm)."
+                    echo "release-vN.M branches must keep pyproject.toml on their own MAJOR.MINOR so"
+                    echo "timestamp_version publishes N.M.TIMESTAMP. Revert the version bump or branch from main."
+                    exit 1
+                  fi
+                  echo "OK: pyproject.toml $pkg_ver is on the $branch_mm line."
       - codeartifact/init:
           tool: pip
       - export-uv-auth
@@ -138,6 +164,7 @@ workflows:
               only: /^release-v\d+\.\d+$/
       - publish-package:
           name: publish-package-release
+          assert-release-version: true
           context: [sdlc, codeartifact-dev]
           requires: [approve-release-publish]
           filters:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,10 @@
   run behind the manual `approve-release-publish` gate, while `main`
   continues to auto-publish on merge. See
   `docs/sdlc/sdlc-cicd-guide-backend.md` §4b.
+- `release-vN.M` branches must keep `pyproject.toml` on their own
+  `MAJOR.MINOR` so `timestamp_version` publishes `N.M.TIMESTAMP`. CI enforces
+  this — the `publish-package-release` job fails if the version line drifts
+  from the branch.
 
 ## Release 2.0.7
 - Add configurable DuckDB memory limit via `DUCKDB_MEMORY_LIMIT` environment variable


### PR DESCRIPTION
## Summary
Follow-up to the per-MINOR-line hotfix CI (DFM-4530). The `publish-package-release` job reuses `publish-package`, which derives the published version from `pyproject.toml` via `codeartifact/timestamp_version`. Nothing prevented a stray version bump on a `release-vN.M` branch from publishing out-of-line artifacts (e.g. a higher MINOR's timestamp build off an older release line).

This adds an `assert-release-version` guard (wired on `publish-package-release`) that fails the build if `pyproject.toml`'s MAJOR.MINOR drifts from the `release-vN.M` branch line. Mirrors the fix in visualfabriq/vf_initialize_data#261 (Finding 2) and visualfabriq/translate#62.

## Test plan
- [ ] CircleCI config validates
- [ ] `main` publish unaffected (guard defaults off)
- [ ] A `release-vN.M` branch with a mismatched `pyproject.toml` version fails the publish

---
jira: DFM-4530