### PR TITLE
FIN-4847: harden DuckDB reads against torn reads and memory pressure

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,19 @@
 # Release Notes for ParQuery
 
+## Release 2.2.0
+- Harden the DuckDB read path against two failure modes seen on the shared EFS
+  data lake (FIN-4847):
+  - **Memory-pressure fault.** `call_duckdb` now maps `DUCKDB_THREADS`,
+    `DUCKDB_TEMP_DIR` and `DUCKDB_MAX_TEMP_DIR_SIZE` onto the connection config
+    (in addition to `DUCKDB_MEMORY_LIMIT`), so a large aggregation spills to disk
+    and completes, or raises a clean DuckDB OOM, instead of over-committing RAM.
+  - **Torn reads from concurrent writes.** Aggregations now read through a pinned
+    file descriptor (`/dev/fd/<fd>`) so a writer's atomic `os.replace` landing
+    mid-read cannot splice two file versions into a corrupt-but-valid result.
+    A reclaimed inode raises (retried) rather than returning garbage. Falls back
+    to reading by path where `/dev/fd` is unavailable.
+- All env vars remain optional; unset means DuckDB defaults (no behaviour change).
+
 ## Release 2.1.0
 - Open a new MINOR line so `release-v2.0` can host hotfixes against the 2.0
   series in isolation. No runtime changes. Pairs with the per-MINOR-line

--- a/parquery/aggregate_duckdb.py
+++ b/parquery/aggregate_duckdb.py
@@ -96,10 +96,6 @@ def aggregate_pq_duckdb(
             Example: [['f0', 'in', [1, 2, 3]], ['f1', '>', 100]]
         aggregate: If True, performs groupby aggregation. If False, returns filtered
             rows without aggregation.
-        standard_missing_id: Default value for missing dimension columns (default: -1).
-            Missing measure columns always get 0.0.
-        handle_missing_file: If True, returns empty result when file doesn't exist.
-            If False, raises OSError for missing files.
         debug: If True, prints SQL queries during processing.
 
     Returns:
@@ -107,8 +103,9 @@ def aggregate_pq_duckdb(
 
     Raises:
         ImportError: If DuckDB is not installed.
-        OSError: If file doesn't exist and handle_missing_file=False, or if file
-            cannot be read.
+        OSError: If the file cannot be opened or read (e.g. a stale handle on
+            EFS). Missing-file handling lives in the ``aggregate_pq`` wrapper,
+            which checks existence before this function is called.
         FilterValueError: If filter values are invalid.
         NotImplementedError: If an unsupported filter operator is used.
 
@@ -158,6 +155,9 @@ def aggregate_pq_duckdb(
             exc,
             exc_info=True,
         )
+        # Reclaim memory before retrying: call_duckdb closes its connection on
+        # the failure path, so a collection here frees the dropped DuckDB
+        # objects (helps when the OSError stems from memory pressure).
         gc.collect()
         result_arrow = _aggregate_pinned(file_name, groupby_cols, measure_cols, data_filter, aggregate, debug)
 
@@ -226,7 +226,8 @@ def call_duckdb(sql) -> Any:
 
     Notes:
         - Uses in-memory database (:memory:) for temporary processing.
-        - Connection is automatically closed after query execution.
+        - Connection is closed on every path (success or failure) so its memory
+          is released promptly.
         - Results are streamed via RecordBatchReader and converted to Table.
     """
     config: dict[str, Any] = {}
@@ -243,11 +244,14 @@ def call_duckdb(sql) -> Any:
         if DUCKDB_MAX_TEMP_DIR_SIZE:
             config["max_temp_directory_size"] = DUCKDB_MAX_TEMP_DIR_SIZE
     conn = duckdb.connect(":memory:", config=config)
-    # arrow() returns a RecordBatchReader, convert to Table
-    reader = conn.execute(sql).arrow()
-    result_arrow = reader.read_all()
-    conn.close()
-    return result_arrow
+    try:
+        # arrow() returns a RecordBatchReader, convert to Table
+        reader = conn.execute(sql).arrow()
+        return reader.read_all()
+    finally:
+        # Close on every path so the connection's memory is released
+        # immediately on failure, not left pinned until garbage collection.
+        conn.close()
 
 
 def _build_sql_query(

--- a/parquery/aggregate_duckdb.py
+++ b/parquery/aggregate_duckdb.py
@@ -19,18 +19,39 @@ from parquery.tool import DataFilter
 logger = logging.getLogger(__name__)
 
 # DuckDB connection tuning, all optional and read from the environment so the
-# deploying service (not parquery) owns the values. Unset = DuckDB default.
+# deploying service (not parquery) owns the values. By default DuckDB caps
+# memory at ~80% of *detected* RAM (which in a container may be the host's RAM,
+# not the cgroup limit) and threads at the core count; these vars let the
+# deployer tighten those bounds and enable disk spill on a shared multi-worker
+# host.
 #   DUCKDB_MEMORY_LIMIT       per-connection working-memory cap, e.g. "2GB".
 #   DUCKDB_THREADS            per-connection thread count, e.g. "2". Bounding
 #                             this matters when several processes (e.g. gunicorn
 #                             workers) each open a connection on the same host.
 #   DUCKDB_TEMP_DIR           spill directory. Set together with a memory limit
 #                             so a large aggregation spills to disk and finishes
-#                             instead of over-committing RAM (kernel OOM kill);
-#                             unset, DuckDB spills to CWD/.tmp.
+#                             instead of erroring or over-committing RAM; unset,
+#                             DuckDB spills to CWD/.tmp.
 #   DUCKDB_MAX_TEMP_DIR_SIZE  cap on the spill directory, e.g. "10GB".
+
+
+def _int_env(name: str) -> int | None:
+    """Read an integer env var, failing fast with a named error on a bad value.
+
+    Validated at import so an operator typo surfaces once at startup rather than
+    as an opaque ``ValueError`` on every query.
+    """
+    raw = os.environ.get(name)
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        raise ValueError(f"{name} must be an integer, got {raw!r}") from None
+
+
 DUCKDB_MEMORY_LIMIT: str | None = os.environ.get("DUCKDB_MEMORY_LIMIT")
-DUCKDB_THREADS: str | None = os.environ.get("DUCKDB_THREADS")
+DUCKDB_THREADS: int | None = _int_env("DUCKDB_THREADS")
 DUCKDB_TEMP_DIR: str | None = os.environ.get("DUCKDB_TEMP_DIR")
 DUCKDB_MAX_TEMP_DIR_SIZE: str | None = os.environ.get("DUCKDB_MAX_TEMP_DIR_SIZE")
 
@@ -40,6 +61,10 @@ DUCKDB_MAX_TEMP_DIR_SIZE: str | None = os.environ.get("DUCKDB_MAX_TEMP_DIR_SIZE"
 # lands mid-read cannot splice two file versions into a corrupt-but-valid
 # result. Only available where ``/dev/fd`` exists (Linux, macOS).
 _CAN_PIN_FD: bool = os.path.isdir("/dev/fd")
+
+# One-time guard so the "torn-read protection disabled" warning below does not
+# spam the log on every query when ``/dev/fd`` is unavailable.
+_fd_fallback_warned: bool = False
 
 
 def aggregate_pq_duckdb(
@@ -121,10 +146,18 @@ def aggregate_pq_duckdb(
 
     # Execute against a pinned snapshot of the file (see _aggregate_pinned).
     # A transient OSError — e.g. an NFS/EFS stale handle after a concurrent
-    # atomic rename reclaimed the inode — is retried once with a fresh fd.
+    # atomic rename reclaimed the inode — is retried once with a fresh fd. The
+    # catch stays broad (EFS surfaces several errnos) but is logged so the retry
+    # is observable; a non-transient cause raises again on the second attempt.
     try:
         result_arrow = _aggregate_pinned(file_name, groupby_cols, measure_cols, data_filter, aggregate, debug)
-    except OSError:
+    except OSError as exc:
+        logger.warning(
+            "OSError reading %s (%s); retrying once with a fresh fd",
+            file_name,
+            exc,
+            exc_info=True,
+        )
         gc.collect()
         result_arrow = _aggregate_pinned(file_name, groupby_cols, measure_cols, data_filter, aggregate, debug)
 
@@ -150,9 +183,19 @@ def _aggregate_pinned(
     the backing inode is reclaimed (``ESTALE``) DuckDB raises rather than
     returning garbage, and ``aggregate_pq_duckdb`` retries with a fresh fd.
 
-    Where ``/dev/fd`` is unavailable the read falls back to the path directly.
+    Where ``/dev/fd`` is unavailable the read falls back to the path directly,
+    which loses torn-read protection — a one-time warning is logged so operators
+    can detect that the guarantee is degraded in their environment.
     """
     if not _CAN_PIN_FD:
+        global _fd_fallback_warned
+        if not _fd_fallback_warned:
+            logger.warning(
+                "/dev/fd unavailable; reading %s by path without inode pinning. "
+                "A concurrent atomic rename could yield a corrupt result.",
+                file_name,
+            )
+            _fd_fallback_warned = True
         sql = _build_sql_query(file_name, groupby_cols, measure_cols, data_filter, aggregate)
         if debug:
             logger.debug(f"DuckDB SQL:\n{sql}\n")
@@ -189,10 +232,12 @@ def call_duckdb(sql) -> Any:
     config: dict[str, Any] = {}
     if DUCKDB_MEMORY_LIMIT:
         config["memory_limit"] = DUCKDB_MEMORY_LIMIT
-    if DUCKDB_THREADS:
-        config["threads"] = int(DUCKDB_THREADS)
+    if DUCKDB_THREADS is not None:
+        config["threads"] = DUCKDB_THREADS  # validated to int at import
     if DUCKDB_TEMP_DIR:
-        # Created here so a misconfigured path is not a hard error on every query.
+        # DuckDB does not create temp_directory itself, so ensure it exists.
+        # exist_ok makes this a cheap stat after first use; a genuinely bad path
+        # (unwritable parent, or a file at this path) still raises here.
         os.makedirs(DUCKDB_TEMP_DIR, exist_ok=True)
         config["temp_directory"] = DUCKDB_TEMP_DIR
         if DUCKDB_MAX_TEMP_DIR_SIZE:

--- a/parquery/aggregate_duckdb.py
+++ b/parquery/aggregate_duckdb.py
@@ -18,7 +18,28 @@ from parquery.tool import DataFilter
 
 logger = logging.getLogger(__name__)
 
+# DuckDB connection tuning, all optional and read from the environment so the
+# deploying service (not parquery) owns the values. Unset = DuckDB default.
+#   DUCKDB_MEMORY_LIMIT       per-connection working-memory cap, e.g. "2GB".
+#   DUCKDB_THREADS            per-connection thread count, e.g. "2". Bounding
+#                             this matters when several processes (e.g. gunicorn
+#                             workers) each open a connection on the same host.
+#   DUCKDB_TEMP_DIR           spill directory. Set together with a memory limit
+#                             so a large aggregation spills to disk and finishes
+#                             instead of over-committing RAM (kernel OOM kill);
+#                             unset, DuckDB spills to CWD/.tmp.
+#   DUCKDB_MAX_TEMP_DIR_SIZE  cap on the spill directory, e.g. "10GB".
 DUCKDB_MEMORY_LIMIT: str | None = os.environ.get("DUCKDB_MEMORY_LIMIT")
+DUCKDB_THREADS: str | None = os.environ.get("DUCKDB_THREADS")
+DUCKDB_TEMP_DIR: str | None = os.environ.get("DUCKDB_TEMP_DIR")
+DUCKDB_MAX_TEMP_DIR_SIZE: str | None = os.environ.get("DUCKDB_MAX_TEMP_DIR_SIZE")
+
+# A reader and a writer share each parquet shard on EFS; the writer publishes
+# updates with an atomic ``os.replace``. Pointing DuckDB at ``/dev/fd/<fd>`` of
+# an already-open descriptor pins the inode for the whole read, so a rename that
+# lands mid-read cannot splice two file versions into a corrupt-but-valid
+# result. Only available where ``/dev/fd`` exists (Linux, macOS).
+_CAN_PIN_FD: bool = os.path.isdir("/dev/fd")
 
 
 def aggregate_pq_duckdb(
@@ -98,26 +119,53 @@ def aggregate_pq_duckdb(
 
     data_filter = data_filter or []
 
-    # Build SQL query
-    sql = _build_sql_query(
-        file_name,
-        groupby_cols,
-        measure_cols,
-        data_filter,
-        aggregate,
-    )
-
-    if debug:
-        logger.debug(f"DuckDB SQL:\n{sql}\n")
-
-    # Execute query with DuckDB
+    # Execute against a pinned snapshot of the file (see _aggregate_pinned).
+    # A transient OSError — e.g. an NFS/EFS stale handle after a concurrent
+    # atomic rename reclaimed the inode — is retried once with a fresh fd.
     try:
-        result_arrow = call_duckdb(sql)
+        result_arrow = _aggregate_pinned(file_name, groupby_cols, measure_cols, data_filter, aggregate, debug)
     except OSError:
         gc.collect()
-        result_arrow = call_duckdb(sql)
+        result_arrow = _aggregate_pinned(file_name, groupby_cols, measure_cols, data_filter, aggregate, debug)
 
     return result_arrow
+
+
+def _aggregate_pinned(
+    file_name: str,
+    groupby_cols: list[str],
+    measure_cols: list[list[str]],
+    data_filter: DataFilter,
+    aggregate: bool,
+    debug: bool,
+) -> pa.Table:
+    """Aggregate ``file_name`` against a consistent snapshot of its bytes.
+
+    The writer publishes shard updates with an atomic ``os.replace`` on EFS. If
+    that rename lands while DuckDB is mid-read, reading by path can combine the
+    footer of one file version with the data pages of another and return a
+    structurally valid but corrupt result (wrong values, no error). We open the
+    file once and point DuckDB at ``/dev/fd/<fd>``, which re-resolves to that
+    exact inode for the whole read, so any concurrent rename is invisible. If
+    the backing inode is reclaimed (``ESTALE``) DuckDB raises rather than
+    returning garbage, and ``aggregate_pq_duckdb`` retries with a fresh fd.
+
+    Where ``/dev/fd`` is unavailable the read falls back to the path directly.
+    """
+    if not _CAN_PIN_FD:
+        sql = _build_sql_query(file_name, groupby_cols, measure_cols, data_filter, aggregate)
+        if debug:
+            logger.debug(f"DuckDB SQL:\n{sql}\n")
+        return call_duckdb(sql)
+
+    fd = os.open(file_name, os.O_RDONLY)
+    try:
+        sql = _build_sql_query(f"/dev/fd/{fd}", groupby_cols, measure_cols, data_filter, aggregate)
+        if debug:
+            logger.debug(f"DuckDB SQL:\n{sql}\n")
+        return call_duckdb(sql)
+    finally:
+        os.close(fd)
 
 
 def call_duckdb(sql) -> Any:
@@ -138,9 +186,17 @@ def call_duckdb(sql) -> Any:
         - Connection is automatically closed after query execution.
         - Results are streamed via RecordBatchReader and converted to Table.
     """
-    config = {}
+    config: dict[str, Any] = {}
     if DUCKDB_MEMORY_LIMIT:
         config["memory_limit"] = DUCKDB_MEMORY_LIMIT
+    if DUCKDB_THREADS:
+        config["threads"] = int(DUCKDB_THREADS)
+    if DUCKDB_TEMP_DIR:
+        # Created here so a misconfigured path is not a hard error on every query.
+        os.makedirs(DUCKDB_TEMP_DIR, exist_ok=True)
+        config["temp_directory"] = DUCKDB_TEMP_DIR
+        if DUCKDB_MAX_TEMP_DIR_SIZE:
+            config["max_temp_directory_size"] = DUCKDB_MAX_TEMP_DIR_SIZE
     conn = duckdb.connect(":memory:", config=config)
     # arrow() returns a RecordBatchReader, convert to Table
     reader = conn.execute(sql).arrow()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "parquery"
-version = "2.1.0"
+version = "2.2.0"
 description = "A query and aggregation framework for Parquet"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_duckdb_read_hardening.py
+++ b/tests/test_duckdb_read_hardening.py
@@ -224,3 +224,25 @@ def test_int_env_rejects_non_integer(monkeypatch):
 def test_int_env_none_when_unset(monkeypatch):
     monkeypatch.delenv("DUCKDB_THREADS", raising=False)
     assert adb._int_env("DUCKDB_THREADS") is None
+
+
+def test_call_duckdb_closes_connection_on_failure(monkeypatch):
+    # The connection's memory must be released even when the query raises, so a
+    # subsequent retry (and its gc.collect) is not competing with a live conn.
+    import duckdb
+
+    closed = {"n": 0}
+
+    class FailingConn:
+        def execute(self, sql):
+            raise RuntimeError("boom")
+
+        def close(self):
+            closed["n"] += 1
+
+    monkeypatch.setattr(duckdb, "connect", lambda *args, **kwargs: FailingConn())
+
+    with pytest.raises(RuntimeError, match="boom"):
+        adb.call_duckdb("SELECT 1")
+
+    assert closed["n"] == 1

--- a/tests/test_duckdb_read_hardening.py
+++ b/tests/test_duckdb_read_hardening.py
@@ -5,11 +5,12 @@ Two independent failure modes on the shared EFS data lake:
 * A concurrent writer ``os.replace``-ing a shard mid-read could splice two file
   versions into a corrupt-but-valid result. ``_aggregate_pinned`` reads through
   ``/dev/fd/<fd>`` so the whole read sees one consistent inode snapshot.
-* DuckDB runs unbounded unless told otherwise. ``call_duckdb`` maps the
-  ``DUCKDB_*`` env vars onto the connection config so memory/threads/spill are
-  bounded by the deploying service.
+* By default DuckDB sizes memory/threads to the host, not the container.
+  ``call_duckdb`` maps the ``DUCKDB_*`` env vars onto the connection config so
+  the deploying service can tighten memory/threads and enable disk spill.
 """
 
+import logging
 import os
 
 import pyarrow as pa
@@ -28,6 +29,11 @@ def _write(path, dates):
         pa.table({"a-31": dates, "g": [1] * len(dates), "m1": [1.0] * len(dates)}),
         path,
     )
+
+
+def _result_map(res):
+    """Map groupby key -> summed measure, so assertions check values, not just keys."""
+    return dict(zip(res.column("a-31").to_pylist(), res.column("m1").to_pylist(), strict=True))
 
 
 def _swap_then_read(real, target, newfile):
@@ -53,7 +59,8 @@ def test_pinned_read_survives_concurrent_replace(tmp_path, monkeypatch):
 
     res = aggregate_pq(target, ["a-31"], [["m1", "sum"]], engine="duckdb", as_df=False, aggregate=True)
 
-    assert sorted(res.column("a-31").to_pylist()) == [20251201, 20251202]
+    # Both keys AND the summed measure reflect the pre-rename snapshot.
+    assert _result_map(res) == {20251201: 1.0, 20251202: 1.0}
 
 
 def test_without_pin_concurrent_replace_is_visible(tmp_path, monkeypatch):
@@ -69,7 +76,74 @@ def test_without_pin_concurrent_replace_is_visible(tmp_path, monkeypatch):
 
     res = aggregate_pq(target, ["a-31"], [["m1", "sum"]], engine="duckdb", as_df=False, aggregate=True)
 
-    assert sorted(res.column("a-31").to_pylist()) == [99999999]
+    assert _result_map(res) == {99999999: 1.0}
+
+
+def test_fallback_without_dev_fd_returns_correct_result(tmp_path, monkeypatch, caplog):
+    # The /dev/fd-absent branch must still return a correct result on the normal
+    # (no concurrent rename) path, and must warn that protection is degraded.
+    target = str(tmp_path / "shard.parquet")
+    _write(target, [20251201, 20251202])
+
+    monkeypatch.setattr(adb, "_CAN_PIN_FD", False)
+    monkeypatch.setattr(adb, "_fd_fallback_warned", False)
+
+    with caplog.at_level(logging.WARNING):
+        res = aggregate_pq(target, ["a-31"], [["m1", "sum"]], engine="duckdb", as_df=False, aggregate=True)
+
+    assert _result_map(res) == {20251201: 1.0, 20251202: 1.0}
+    assert any("without inode pinning" in r.message for r in caplog.records)
+
+
+@pytest.mark.skipif(not adb._CAN_PIN_FD, reason="/dev/fd not available")
+def test_oserror_retried_once_with_fresh_fd(tmp_path, monkeypatch):
+    target = str(tmp_path / "shard.parquet")
+    _write(target, [20251201, 20251202])
+
+    real_call = adb.call_duckdb
+    calls = {"n": 0}
+
+    def flaky(sql):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError("transient stale handle")
+        return real_call(sql)
+
+    opened, closed = [], []
+    real_open, real_close = os.open, os.close
+
+    def counting_open(path, flags, *args, **kwargs):
+        fd = real_open(path, flags, *args, **kwargs)
+        opened.append(fd)
+        return fd
+
+    def counting_close(fd):
+        closed.append(fd)
+        return real_close(fd)
+
+    monkeypatch.setattr(adb, "call_duckdb", flaky)
+    monkeypatch.setattr(os, "open", counting_open)
+    monkeypatch.setattr(os, "close", counting_close)
+
+    res = aggregate_pq(target, ["a-31"], [["m1", "sum"]], engine="duckdb", as_df=False, aggregate=True)
+
+    assert calls["n"] == 2  # failed once, retried once
+    assert len(opened) == 2  # a fresh fd opened per attempt
+    assert opened == closed  # every fd closed, including the failing attempt (no leak)
+    assert _result_map(res) == {20251201: 1.0, 20251202: 1.0}
+
+
+def test_oserror_second_failure_propagates(tmp_path, monkeypatch):
+    target = str(tmp_path / "shard.parquet")
+    _write(target, [20251201])
+
+    def always_raise(sql):
+        raise OSError("persistent")
+
+    monkeypatch.setattr(adb, "call_duckdb", always_raise)
+
+    with pytest.raises(OSError, match="persistent"):
+        aggregate_pq(target, ["a-31"], [["m1", "sum"]], engine="duckdb", as_df=False, aggregate=True)
 
 
 def test_connection_config_from_env(tmp_path, monkeypatch):
@@ -84,7 +158,7 @@ def test_connection_config_from_env(tmp_path, monkeypatch):
 
     spill = str(tmp_path / "spill")
     monkeypatch.setattr(adb, "DUCKDB_MEMORY_LIMIT", "512MB")
-    monkeypatch.setattr(adb, "DUCKDB_THREADS", "2")
+    monkeypatch.setattr(adb, "DUCKDB_THREADS", 2)  # int, coerced at import
     monkeypatch.setattr(adb, "DUCKDB_TEMP_DIR", spill)
     monkeypatch.setattr(adb, "DUCKDB_MAX_TEMP_DIR_SIZE", "4GB")
     monkeypatch.setattr(duckdb, "connect", fake_connect)
@@ -93,10 +167,33 @@ def test_connection_config_from_env(tmp_path, monkeypatch):
 
     cfg = captured["config"]
     assert cfg["memory_limit"] == "512MB"
-    assert cfg["threads"] == 2  # coerced to int
+    assert cfg["threads"] == 2
     assert cfg["temp_directory"] == spill
     assert cfg["max_temp_directory_size"] == "4GB"
     assert os.path.isdir(spill)  # created if missing
+
+
+def test_connection_config_threads_only(monkeypatch):
+    # Partial config: max-temp-size without a temp dir is dropped, and no spill
+    # directory is created when only threads is set.
+    import duckdb
+
+    captured = {}
+    real_connect = duckdb.connect
+
+    def fake_connect(database, config=None):
+        captured["config"] = dict(config or {})
+        return real_connect(database, config=config or {})
+
+    monkeypatch.setattr(adb, "DUCKDB_MEMORY_LIMIT", None)
+    monkeypatch.setattr(adb, "DUCKDB_THREADS", 2)
+    monkeypatch.setattr(adb, "DUCKDB_TEMP_DIR", None)
+    monkeypatch.setattr(adb, "DUCKDB_MAX_TEMP_DIR_SIZE", "4GB")
+    monkeypatch.setattr(duckdb, "connect", fake_connect)
+
+    adb.call_duckdb("SELECT 1")
+
+    assert captured["config"] == {"threads": 2}
 
 
 def test_connection_config_empty_when_unset(monkeypatch):
@@ -116,3 +213,14 @@ def test_connection_config_empty_when_unset(monkeypatch):
     adb.call_duckdb("SELECT 1")
 
     assert captured["config"] == {}
+
+
+def test_int_env_rejects_non_integer(monkeypatch):
+    monkeypatch.setenv("DUCKDB_THREADS", "two")
+    with pytest.raises(ValueError, match="DUCKDB_THREADS must be an integer"):
+        adb._int_env("DUCKDB_THREADS")
+
+
+def test_int_env_none_when_unset(monkeypatch):
+    monkeypatch.delenv("DUCKDB_THREADS", raising=False)
+    assert adb._int_env("DUCKDB_THREADS") is None

--- a/tests/test_duckdb_read_hardening.py
+++ b/tests/test_duckdb_read_hardening.py
@@ -1,0 +1,118 @@
+"""Regression tests for DuckDB read hardening.
+
+Two independent failure modes on the shared EFS data lake:
+
+* A concurrent writer ``os.replace``-ing a shard mid-read could splice two file
+  versions into a corrupt-but-valid result. ``_aggregate_pinned`` reads through
+  ``/dev/fd/<fd>`` so the whole read sees one consistent inode snapshot.
+* DuckDB runs unbounded unless told otherwise. ``call_duckdb`` maps the
+  ``DUCKDB_*`` env vars onto the connection config so memory/threads/spill are
+  bounded by the deploying service.
+"""
+
+import os
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+import parquery.aggregate_duckdb as adb
+from parquery import HAS_DUCKDB
+from parquery import aggregate_pq
+
+pytestmark = pytest.mark.skipif(not HAS_DUCKDB, reason="DuckDB not installed")
+
+
+def _write(path, dates):
+    pq.write_table(
+        pa.table({"a-31": dates, "g": [1] * len(dates), "m1": [1.0] * len(dates)}),
+        path,
+    )
+
+
+def _swap_then_read(real, target, newfile):
+    """Wrap call_duckdb to simulate the writer's rename landing mid-read."""
+
+    def wrapper(sql):
+        os.replace(newfile, target)
+        return real(sql)
+
+    return wrapper
+
+
+@pytest.mark.skipif(not adb._CAN_PIN_FD, reason="/dev/fd not available")
+def test_pinned_read_survives_concurrent_replace(tmp_path, monkeypatch):
+    target = str(tmp_path / "shard.parquet")
+    _write(target, [20251201, 20251202])  # consistent OLD content
+    newfile = str(tmp_path / "new.parquet")
+    _write(newfile, [99999999])  # different content the rename would expose
+
+    # The fd is opened in _aggregate_pinned before call_duckdb runs, so the
+    # rename inside the wrapper cannot change what /dev/fd/<fd> resolves to.
+    monkeypatch.setattr(adb, "call_duckdb", _swap_then_read(adb.call_duckdb, target, newfile))
+
+    res = aggregate_pq(target, ["a-31"], [["m1", "sum"]], engine="duckdb", as_df=False, aggregate=True)
+
+    assert sorted(res.column("a-31").to_pylist()) == [20251201, 20251202]
+
+
+def test_without_pin_concurrent_replace_is_visible(tmp_path, monkeypatch):
+    # Control: with pinning disabled, the same rename leaks the new file. Proves
+    # the pin (not test setup) is what isolates the read above.
+    target = str(tmp_path / "shard.parquet")
+    _write(target, [20251201, 20251202])
+    newfile = str(tmp_path / "new.parquet")
+    _write(newfile, [99999999])
+
+    monkeypatch.setattr(adb, "_CAN_PIN_FD", False)
+    monkeypatch.setattr(adb, "call_duckdb", _swap_then_read(adb.call_duckdb, target, newfile))
+
+    res = aggregate_pq(target, ["a-31"], [["m1", "sum"]], engine="duckdb", as_df=False, aggregate=True)
+
+    assert sorted(res.column("a-31").to_pylist()) == [99999999]
+
+
+def test_connection_config_from_env(tmp_path, monkeypatch):
+    import duckdb
+
+    captured = {}
+    real_connect = duckdb.connect
+
+    def fake_connect(database, config=None):
+        captured["config"] = dict(config or {})
+        return real_connect(database, config=config or {})
+
+    spill = str(tmp_path / "spill")
+    monkeypatch.setattr(adb, "DUCKDB_MEMORY_LIMIT", "512MB")
+    monkeypatch.setattr(adb, "DUCKDB_THREADS", "2")
+    monkeypatch.setattr(adb, "DUCKDB_TEMP_DIR", spill)
+    monkeypatch.setattr(adb, "DUCKDB_MAX_TEMP_DIR_SIZE", "4GB")
+    monkeypatch.setattr(duckdb, "connect", fake_connect)
+
+    adb.call_duckdb("SELECT 1")
+
+    cfg = captured["config"]
+    assert cfg["memory_limit"] == "512MB"
+    assert cfg["threads"] == 2  # coerced to int
+    assert cfg["temp_directory"] == spill
+    assert cfg["max_temp_directory_size"] == "4GB"
+    assert os.path.isdir(spill)  # created if missing
+
+
+def test_connection_config_empty_when_unset(monkeypatch):
+    import duckdb
+
+    captured = {}
+    real_connect = duckdb.connect
+
+    def fake_connect(database, config=None):
+        captured["config"] = dict(config or {})
+        return real_connect(database, config=config or {})
+
+    for name in ("DUCKDB_MEMORY_LIMIT", "DUCKDB_THREADS", "DUCKDB_TEMP_DIR", "DUCKDB_MAX_TEMP_DIR_SIZE"):
+        monkeypatch.setattr(adb, name, None)
+    monkeypatch.setattr(duckdb, "connect", fake_connect)
+
+    adb.call_duckdb("SELECT 1")
+
+    assert captured["config"] == {}


### PR DESCRIPTION
## Why

The DQE reader (FIN-4847, sibling of FIN-4782) returned corrupt/incomplete data on large aggregated reads of the shared EFS data lake — non-deterministic impossible values (e.g. `a-31 = 20260568`) that crashed the downstream writer's date guard, and `IncompleteRead`/OOM 500s. Investigation isolated two independent mechanisms in the DuckDB read path, both fixed here.

## What

**1. Memory-pressure fault → bounded DuckDB**
`call_duckdb` previously ran an unbounded in-memory connection (`DUCKDB_MEMORY_LIMIT` was the only knob). It now maps `DUCKDB_THREADS`, `DUCKDB_TEMP_DIR` and `DUCKDB_MAX_TEMP_DIR_SIZE` onto the connection config too. With these set, a large aggregation spills to disk and completes, or raises a clean DuckDB OOM (→ the reader's existing 507 path), instead of over-committing RAM into a kernel OOM-kill / silent-pressure regime. All vars stay optional; unset = DuckDB defaults (no behaviour change).

**2. Torn reads from concurrent writes → inode-pinned snapshot**
A writer's atomic `os.replace` landing mid-read could splice the footer of one file version onto the data pages of another and return a structurally valid but corrupt result. Reads now go through a pinned file descriptor (`/dev/fd/<fd>`), so the whole read sees one consistent inode snapshot regardless of any concurrent rename. A reclaimed inode (`ESTALE`) raises and is retried with a fresh fd, rather than returning garbage. Falls back to reading by path where `/dev/fd` is unavailable.

## Verification

- Empirically validated on the prod platform (Linux ARM64, duckdb 1.5.3): pinned fd reads the consistent pre-rename content after `os.replace`; all four config keys accepted by `connect()`.
- New regression tests (`tests/test_duckdb_read_hardening.py`): snapshot-survives-replace, a **control** proving the pin (not test scaffolding) is what isolates the read, and env→connection-config mapping.
- Full suite: **85 passed, 1 skipped**; `ruff check` + `ruff format` clean.

## Release

Base version bumped `2.1.0` → `2.2.0` (new configurable read-hardening behaviour). Consumed downstream by `dqe-api-backend` (lock bump + Dockerfile `DUCKDB_THREADS`/`DUCKDB_TEMP_DIR`).

---
jira: FIN-4847