### PR TITLE
FIN-4849: isolate DuckDB spill dir per connection (fix reader wrong-data under load)

### DIFF
--- a/parquery/aggregate_duckdb.py
+++ b/parquery/aggregate_duckdb.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import gc
 import logging
 import os
+import shutil
+import uuid
 from typing import Any
 
 try:
@@ -235,12 +237,21 @@ def call_duckdb(sql) -> Any:
         config["memory_limit"] = DUCKDB_MEMORY_LIMIT
     if DUCKDB_THREADS is not None:
         config["threads"] = DUCKDB_THREADS  # validated to int at import
+    conn_temp_dir: str | None = None
     if DUCKDB_TEMP_DIR:
+        # Every :memory: connection spills to ``duckdb_temp_storage_DEFAULT-N.tmp``;
+        # with a shared temp_directory the concurrent reader processes (one DuckDB
+        # connection per gunicorn worker) collide on the same path and clobber each
+        # other's spill blocks. That surfaces either as an IO error ("Could not read
+        # enough bytes from file") or, worse, a silently wrong aggregation when a
+        # clobbered block happens to read back as valid. Give each connection its own
+        # subdirectory so spills can never collide. See FIN-4849.
+        conn_temp_dir = os.path.join(DUCKDB_TEMP_DIR, f"{os.getpid()}-{uuid.uuid4().hex}")
         # DuckDB does not create temp_directory itself, so ensure it exists.
         # exist_ok makes this a cheap stat after first use; a genuinely bad path
         # (unwritable parent, or a file at this path) still raises here.
-        os.makedirs(DUCKDB_TEMP_DIR, exist_ok=True)
-        config["temp_directory"] = DUCKDB_TEMP_DIR
+        os.makedirs(conn_temp_dir, exist_ok=True)
+        config["temp_directory"] = conn_temp_dir
         if DUCKDB_MAX_TEMP_DIR_SIZE:
             config["max_temp_directory_size"] = DUCKDB_MAX_TEMP_DIR_SIZE
     conn = duckdb.connect(":memory:", config=config)
@@ -252,6 +263,11 @@ def call_duckdb(sql) -> Any:
         # Close on every path so the connection's memory is released
         # immediately on failure, not left pinned until garbage collection.
         conn.close()
+        # Remove this connection's private spill directory. DuckDB deletes its own
+        # .tmp files on close, but the directory itself lingers; clean it up so a
+        # long-lived worker does not accumulate one empty dir per query.
+        if conn_temp_dir is not None:
+            shutil.rmtree(conn_temp_dir, ignore_errors=True)
 
 
 def _build_sql_query(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "parquery"
-version = "2.2.0"
+version = "2.2.1"
 description = "A query and aggregation framework for Parquet"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_duckdb_read_hardening.py
+++ b/tests/test_duckdb_read_hardening.py
@@ -168,9 +168,47 @@ def test_connection_config_from_env(tmp_path, monkeypatch):
     cfg = captured["config"]
     assert cfg["memory_limit"] == "512MB"
     assert cfg["threads"] == 2
-    assert cfg["temp_directory"] == spill
+    # temp_directory is a per-connection subdir under the configured root, not the
+    # root itself, so concurrent connections cannot collide on one spill file
+    # (FIN-4849).
+    assert cfg["temp_directory"] != spill
+    assert os.path.dirname(cfg["temp_directory"]) == spill
     assert cfg["max_temp_directory_size"] == "4GB"
-    assert os.path.isdir(spill)  # created if missing
+    assert os.path.isdir(spill)  # root created if missing
+
+
+def test_spill_dir_unique_per_connection_and_cleaned_up(tmp_path, monkeypatch):
+    # Without isolation every :memory: connection spills to the same
+    # ``duckdb_temp_storage_DEFAULT-0.tmp`` under a shared temp_directory; under
+    # concurrency those paths collide and clobber each other, yielding IO errors
+    # ("Could not read enough bytes") or silently wrong aggregations. Each
+    # connection must get its own spill subdir, removed once the query finishes.
+    # Regression for FIN-4849.
+    import duckdb
+
+    spill = str(tmp_path / "spill")
+    seen = []
+    real_connect = duckdb.connect
+
+    def capturing_connect(database, config=None):
+        temp_dir = (config or {}).get("temp_directory")
+        assert temp_dir is not None
+        assert os.path.isdir(temp_dir)  # created before connect
+        assert os.path.dirname(temp_dir) == spill
+        seen.append(temp_dir)
+        return real_connect(database, config=config or {})
+
+    monkeypatch.setattr(adb, "DUCKDB_TEMP_DIR", spill)
+    monkeypatch.setattr(duckdb, "connect", capturing_connect)
+
+    adb.call_duckdb("SELECT 1")
+    adb.call_duckdb("SELECT 1")
+
+    assert len(seen) == 2
+    assert seen[0] != seen[1]  # distinct spill paths -> no collision
+    assert all(d.startswith(os.path.join(spill, f"{os.getpid()}-")) for d in seen)
+    assert not any(os.path.exists(d) for d in seen)  # cleaned up after each query
+    assert os.listdir(spill) == []  # root retained, no leaked subdirs
 
 
 def test_connection_config_threads_only(monkeypatch):


### PR DESCRIPTION
## Summary

The DQE **reader** intermittently failed (and may have returned wrong aggregations) under load in `ap-northeast-1`. Root cause is in parquery: every `:memory:` DuckDB connection spills to the **same** temp file under a shared `temp_directory`, so concurrent connections (one per gunicorn worker) clobber each other's spill blocks.

This PR gives each connection a **private spill subdirectory** so spills can never collide.

## CloudWatch evidence (`ap-app-dqe-ret-reader-log`)

Errors cluster in stress windows. Captured burst on **2026-06-22 09:15 UTC**:

```
09:15:35.730  ...fact_revenue_plan_value_1_actuals_accruals_8.parquet  → IO Error: Could not read enough bytes from file
              "/tmp/duckdb_spill/duckdb_temp_storage_DEFAULT-0.tmp"
09:15:35.856  ...accruals_11.parquet  → ...duckdb_temp_storage_DEFAULT-0.tmp
09:15:35.925  ...accruals_9.parquet   → ...duckdb_temp_storage_DEFAULT-0.tmp
09:15:37.890  Could not read enough bytes ... DEFAULT-0.tmp / Could not remove file ... No such file or directory
```

Three **different** shard files of the same table fail on the **same** spill file `duckdb_temp_storage_DEFAULT-0.tmp` within ~200 ms. A single serial worker cannot produce different-file failures on the same temp file at the same instant — this only happens when multiple worker processes are mid-read and overwriting one shared spill file.

Frequency over 7 days (spill-collision errors/day), spiking on stress days:

| Day | Errors |
|-----|--------|
| 06-15 | 33 |
| 06-16 | 218 |
| 06-17 | 34 |
| 06-18 | 7 |
| 06-19 | 12 |
| 06-20 | 11 |
| 06-21 | 14 |
| 06-22 | 150 |

## Why it happens

The reader runs `gunicorn --workers 3` (`uvicorn` workers) on a 2 vCPU task with `DUCKDB_TEMP_DIR=/tmp/duckdb_spill`. The `/query` handler calls DuckDB synchronously, so each worker is single-flight → up to **3 concurrent DuckDB connections, one per worker process**.

Every connection opens `duckdb.connect(":memory:")`. For an in-memory DB, DuckDB names its spill files `duckdb_temp_storage_DEFAULT-<n>.tmp` and writes them into the configured `temp_directory`. With a **single shared** `temp_directory`, all 3 processes use the **identical path** `duckdb_temp_storage_DEFAULT-0.tmp`. Under memory pressure (`DUCKDB_MEMORY_LIMIT=2GB`) a large aggregation spills 256 KB blocks to that file, and the processes overwrite each other.

(Reader-only because only the reader uses DuckDB; the workers use plain parquery.)

## Failure modes — what is proven vs. inferred

**Mode 1 — collision → IO error → HTTP 500. Directly observed.**
One connection truncates/removes a block another is mid-read on → `Could not read enough bytes` / `Could not remove file`. These match no transient/OOM/torn-read marker in the reader's `_classify_storage_error`, so they surface as 500. This is the 09:15 burst above.

The vf_dqe client (`retrieve.py`) **raises `DqeHttpError` on any non-200/404** — it does not silently drop a 500 shard. So Mode 1 kills the whole query loudly, which matches FIN-4849's reported symptom ("pipeline gets killed", 502). A 500 does **not** produce a silent partial/under-counted result (hypothesis checked and rejected).

**Mode 2 — silent wrong aggregation. Mechanistically plausible, inferred, not directly captured.**
DuckDB checksums spill blocks, so the *common* clobber (torn/partial/short read) fails the check and becomes Mode 1. The rare tail is a **clean whole-block swap**: connection B writes a complete, valid 256 KB block at the exact offset connection A reads back. B's checksum is valid and nothing validates logical block *ownership*, so A consumes B's data as its own → wrong aggregation, no error, no log line. This is consistent with "hundreds of Mode-1 errors, occasional wrong numbers", but by definition it leaves no trace, so it is inferred, not proven.

**Out of scope (separate pre-existing path):** the client silently `continue`s on a **404** ("shard does not exist", typically writer-side lag). A shard that 404s under load is dropped → under-counted result. This is unrelated to the spill collision (spill errors are 500, never 404), but it is a second silent-wrong-data vector worth a follow-up.

## Fix

In `call_duckdb`, point each connection at `{DUCKDB_TEMP_DIR}/{pid}-{uuid}` instead of the bare root, and `shutil.rmtree` it in `finally`:

- Distinct path per connection ⇒ `DEFAULT-0.tmp` can no longer be shared ⇒ neither Mode 1 nor the Mode 2 tail can occur.
- `pid + uuid` covers cross-process (the live cause) and any future intra-process threadpool concurrency.
- Cleanup in `finally` prevents a long-lived worker accumulating one empty dir per query.

## Note on `max_temp_directory_size`

This cap (`DUCKDB_MAX_TEMP_DIR_SIZE`, `10GB` in infra) is now **per connection** rather than shared across the dir. Worst case ≈ 3 concurrent × 10 GB = 30 GB, well under the 100 GiB reader spill volume. Deliberate, but flagging it.

## Tests

- New `test_spill_dir_unique_per_connection_and_cleaned_up`: distinct, pid-scoped, under-root spill dirs, cleaned up after each query.
- Updated `test_connection_config_from_env` (the old `temp_directory == root` assertion no longer holds — it's now a subdir).
- `pytest tests/test_duckdb_read_hardening.py` → 12 passed; full suite → 93 passed, 1 skipped; `ruff check` clean.

Version: `2.2.0 → 2.2.1`.

---
jira: FIN-4849
