### PR TITLE
DFM-4837: Restrict create-release-branch to main only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,14 +169,12 @@ workflows:
           type: approval
           filters:
             branches:
-              ignore:
+              only:
                 - main
-                - /^release-v\d+\.\d+$/
       - create-release-branch:
           context: [sdlc, codeartifact-dev]
           requires: [approve-create-release-branch]
           filters:
             branches:
-              ignore:
+              only:
                 - main
-                - /^release-v\d+\.\d+$/


### PR DESCRIPTION
## Summary

The `create-release-branch` workflow was filtered to run on every branch *except* `main`/`release-v*`. Inverted the filter so both the approval gate and the job only trigger on `main`.

This aligns with vf_initialize_data PR #265 and standardizes that release branches can only be cut from `main`.

---
jira: DFM-4837