### PR TITLE
FOUN-236: Align release branch CI filter regex with sdlc orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,14 +135,14 @@ workflows:
           requires: [test, test-arm64]
           filters:
             branches:
-              only: /^release-v\d+\.\d+$/
+              only: /^release-v\d+$/
       - publish-package:
           name: publish-package-release
           context: [sdlc, codeartifact-dev]
           requires: [approve-release-publish]
           filters:
             branches:
-              only: /^release-v\d+\.\d+$/
+              only: /^release-v\d+$/
 
   # Feature branches: opt-in dev publish
   publish-dev:
@@ -153,7 +153,7 @@ workflows:
             branches:
               ignore:
                 - main
-                - /^release-v\d+\.\d+$/
+                - /^release-v\d+$/
       - publish-dev:
           context: [sdlc, codeartifact-dev]
           requires: [approve-publish-dev]
@@ -161,7 +161,7 @@ workflows:
             branches:
               ignore:
                 - main
-                - /^release-v\d+\.\d+$/
+                - /^release-v\d+$/
 
   create-release-branch:
     jobs:
@@ -171,7 +171,7 @@ workflows:
             branches:
               ignore:
                 - main
-                - /^release-v\d+\.\d+$/
+                - /^release-v\d+$/
       - create-release-branch:
           context: [sdlc, codeartifact-dev]
           requires: [approve-create-release-branch]
@@ -179,4 +179,4 @@ workflows:
             branches:
               ignore:
                 - main
-                - /^release-v\d+\.\d+$/
+                - /^release-v\d+$/


### PR DESCRIPTION
The sdlc orb's `create-release-branch` (with `release-type: python-package`) names package release branches `release-v{MAJOR}` — e.g. `release-v3` — where `MAJOR` is the major from `pyproject.toml` (`vf-circleci-sdlc-orb`, `src/scripts/release.sh:153-158`).

The CI filters in this repo used `/^release-v\d+\.\d+$/` (matching `release-v3.2`), which **never matches an orb-created branch**. As a result the test / publish / create-release-branch workflows would not fire on the actual release branch.

This aligns all filters with the orb's real naming: `/^release-v\d+$/`.

---
jira: FOUN-236