### PR TITLE
FOUN-236: Align CI release flow with metadata/vf-ms-utils

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,16 +99,8 @@ jobs:
           version: $RELEASE_VERSION
           release-assets: "dist/*.tar.gz dist/*.whl"
 
-  create-release-branch:
-    executor:
-      <<: *python_executor_small
-    steps:
-      - checkout
-      - sdlc/create-release-branch:
-          release-type: python-package
-
 workflows:
-  test:
+  parquery:
     jobs:
       - test:
           context: [sdlc, codeartifact-dev]
@@ -144,9 +136,6 @@ workflows:
             branches:
               only: /^release-v\d+\.\d+$/
 
-  # Feature branches: opt-in dev publish
-  publish-dev:
-    jobs:
       - approve-publish-dev:
           type: approval
           filters:
@@ -157,24 +146,6 @@ workflows:
       - publish-dev:
           context: [sdlc, codeartifact-dev]
           requires: [approve-publish-dev]
-          filters:
-            branches:
-              ignore:
-                - main
-                - /^release-v\d+\.\d+$/
-
-  create-release-branch:
-    jobs:
-      - approve-create-release-branch:
-          type: approval
-          filters:
-            branches:
-              ignore:
-                - main
-                - /^release-v\d+\.\d+$/
-      - create-release-branch:
-          context: [sdlc, codeartifact-dev]
-          requires: [approve-create-release-branch]
           filters:
             branches:
               ignore:


### PR DESCRIPTION
Aligns this repo's CI release flow with the canonical package layout used by [metadata](https://github.com/visualfabriq/metadata/blob/main/.circleci/config.yml) and [vf-ms-utils](https://github.com/visualfabriq/vf-ms-utils/blob/main/.circleci/config.yml).

**Changes**
- **Single workflow** — consolidate the previous `test` + `publish-dev` workflows into one per-repo workflow.
- **Remove `sdlc/create-release-branch`** (job + workflow). The orb names package release branches `release-v{MAJOR}` (e.g. `release-v3`), which never matches the `release-v{MAJOR}.{MINOR}` CI filters. Hotfix branches are cut **manually** (`git checkout -b release-v3.2 …`).

Release publishing (`approve-release-publish` → `publish-package-release`) and the `/^release-v\d+\.\d+$/` filters were already in place.

---
jira: FOUN-236